### PR TITLE
Add html header to say that this is UTF8 (since it is)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
 	<link rel="stylesheet" href="deriviste.css" />
 	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.4/dist/leaflet.css" />
     <link rel="stylesheet" href="https://unpkg.com/mapillary-js@2.15.0/dist/mapillary.min.css" />


### PR DESCRIPTION
index.html is valid UTF8 so stop my firefox console complaining at me.