### PR TITLE
Upon startup, check the browser isn't blocking access to Mapillary

### DIFF
--- a/deriviste.js
+++ b/deriviste.js
@@ -103,6 +103,13 @@ function initialise() {
 		displayKey: getPresetValue
 	}]).on('autocomplete:selected', choosePreset);
 	fetch("presets/presets.json").then(parsePresets);
+
+    // Check we can access Mapillary, in case you're being fancy with browser
+    // extensions that block things.
+    // Is there a mapillary "ping" API URL to use instead?
+    fetch("https://a.mapillary.com/v3/").catch(response => {
+        u("#introduction .inner").append("<p>⚠  Your browser is blocking access to Mapillary, which is needed for Deriviste. Check your browser extensions or adblockers. (PrivacyBadger/uBlock/etc.)</p>");
+    });
 }
 
 function flash(str) {


### PR DESCRIPTION
This can happen by default with PrivacyBadger.

I'm not sure if this is a great thing to do, because web apps should be able to rely on certain things. But it does make the software more robust.

This would fix #8